### PR TITLE
feature: add support for reading the HVAC action

### DIFF
--- a/custom_components/nest_matters/climate.py
+++ b/custom_components/nest_matters/climate.py
@@ -200,7 +200,6 @@ class NestMattersClimate(ClimateEntity):
             self._attr_hvac_action = google_attrs.get("hvac_action")
             self._hvac_action_source = "google"
         else:
-            self._attr_hvac_action = None
             self._hvac_action_source = "unavailable"
 
         # --- Fan / humidity: Google only (no Matter equivalent) ---
@@ -213,12 +212,13 @@ class NestMattersClimate(ClimateEntity):
         else:
             self._fan_source = "unavailable"
 
-        # --- Dynamic features: toggle FAN_MODE based on Google availability ---
+        # --- Dynamic features: toggle FAN_MODE or hvac_action based on Google availability ---
         if google_available:
             self._attr_supported_features = (
                 _BASE_FEATURES | ClimateEntityFeature.FAN_MODE
             )
         else:
+            self._attr_hvac_action = None
             self._attr_supported_features = _BASE_FEATURES
 
     @property

--- a/custom_components/nest_matters/climate.py
+++ b/custom_components/nest_matters/climate.py
@@ -92,7 +92,7 @@ class NestMattersClimate(ClimateEntity):
         # but must exist before the first state write during entity registration.
         self._attr_hvac_mode = None
         self._attr_hvac_modes = []
-        self._attr_hvac_action = "idle"
+        self._attr_hvac_action = None
         self._attr_fan_mode = None
         self._attr_fan_modes = []
         self._attr_target_temperature = None
@@ -104,6 +104,7 @@ class NestMattersClimate(ClimateEntity):
         # Source routing indicators (exposed via extra_state_attributes)
         self._temperature_source: str = "unavailable"
         self._hvac_source: str = "unavailable"
+        self._hvac_action_source: str = "unavailable"
         self._fan_source: str = "unavailable"
 
     async def async_added_to_hass(self) -> None:
@@ -197,9 +198,9 @@ class NestMattersClimate(ClimateEntity):
         if google_available and google_state.attributes:
             google_attrs = google_state.attributes
             self._attr_hvac_action = google_attrs.get("hvac_action")
+            self._hvac_action_source = "google"
         else:
-            # --- Default to idle if Google is unavailable
-            self._attr_hvac_action = "idle"
+            self._hvac_action_source = "unavailable"
 
         # --- Fan / humidity: Google only (no Matter equivalent) ---
         if google_available and google_state.attributes:

--- a/custom_components/nest_matters/climate.py
+++ b/custom_components/nest_matters/climate.py
@@ -200,6 +200,7 @@ class NestMattersClimate(ClimateEntity):
             self._attr_hvac_action = google_attrs.get("hvac_action")
             self._hvac_action_source = "google"
         else:
+            self._attr_hvac_action = None
             self._hvac_action_source = "unavailable"
 
         # --- Fan / humidity: Google only (no Matter equivalent) ---
@@ -226,6 +227,7 @@ class NestMattersClimate(ClimateEntity):
         return {
             "temperature_source": self._temperature_source,
             "hvac_source": self._hvac_source,
+            "hvac_action_source": self._hvac_action_source,
             "fan_source": self._fan_source,
         }
 

--- a/custom_components/nest_matters/climate.py
+++ b/custom_components/nest_matters/climate.py
@@ -92,6 +92,7 @@ class NestMattersClimate(ClimateEntity):
         # but must exist before the first state write during entity registration.
         self._attr_hvac_mode = None
         self._attr_hvac_modes = []
+        self._attr_hvac_action = "idle"
         self._attr_fan_mode = None
         self._attr_fan_modes = []
         self._attr_target_temperature = None
@@ -191,6 +192,14 @@ class NestMattersClimate(ClimateEntity):
             self._hvac_source = "matter (fallback)"
         else:
             self._hvac_source = "unavailable"
+
+        # --- HVAC action: Google only (no Matter equivalent) ---
+        if google_available and google_state.attributes:
+            google_attrs = google_state.attributes
+            self._attr_hvac_action = google_attrs.get("hvac_action")
+        else:
+            # --- Default to idle if Google is unavailable
+            self._attr_hvac_action = "idle"
 
         # --- Fan / humidity: Google only (no Matter equivalent) ---
         if google_available and google_state.attributes:

--- a/custom_components/nest_matters/sensor.py
+++ b/custom_components/nest_matters/sensor.py
@@ -19,6 +19,7 @@ _SOURCE_SENSORS: list[tuple[str, str, str, str | None]] = [
     ("temperature_source", "Temperature Source", "matter", "google"),
     ("hvac_source", "HVAC Source", "google", "matter"),
     ("fan_source", "Fan Source", "google", None),
+    ("hvac_action_source", "HVAC Action Source", "google", None),
 ]
 
 


### PR DESCRIPTION
This pull requests adds support for reading the "hvac_action" from the Google Nest integration.

I figured that this would be a good thing to add, as not only is it exposed through the Nest integration, it would serve as a good automation trigger and overview of what the thermostat is actually doing. I have been using this modified code on my actual Home Assistant instance for a few days. and the change has not caused any other issues to pop up.

Edit: I also slightly updated the code that I wrote in order to make it so that it would stop exposing the HVAC action state if it cannot reach Google's servers, as before the commit "5e8a96d548f5d15f2b9effe9d1a8d80ebfdef595" from my fork, it just simply said that the Thermostat was Idle if it was relying on Matter, now it follows the same road as the Fan mode and simply stops showing it if it doesn't have access to it. I have also tested this change, and it appears to work great on my end. I also created a new sensor for the HVAC action source, but that may end up being redundant, as we already have an HVAC source sensor, but you tell me if you agree with the potential redundancy.

Edit 2: I fixed an issue where if Google's servers became unavailable, it would not correctly update the state, basically counteracting the changes defined in Edit 1.

Edit 3: I moved the line that sets the HVAC action to none to be further down with the dynamic features code because it just felt a little better there, following the conventions set by the fan mode stuff.